### PR TITLE
Correct README to display the correct CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status badge](https://img.shields.io/badge/dynamic/json.svg?label=build&colorB=green&query=status&uri=https%3A%2F%2Fissotm.github.io%2Fbuild.json)](https://issotm.github.io/aevilia.html)
 
-A RPG for the Game Boy Color, written in pure Sharp LR35602 (aka GBz80) assembly.
+A RPG for the Game Boy Color, written in pure Sharp LR35902 (aka GBz80) assembly.
 
 Note : this is neither a tutorial nor a walkthrough for the game.
 


### PR DESCRIPTION
The Gameboy's CPU is Sharp LR35902, not Sharp LR35602